### PR TITLE
drivers: can: Add support for CAN driver for MSPM0G3xx

### DIFF
--- a/dts/ti/mspm0/mspm0g3507-pinctrl.dtsi
+++ b/dts/ti/mspm0/mspm0g3507-pinctrl.dtsi
@@ -91,4 +91,13 @@
 		pinmux = <MSP_PINMUX(45,UNCONNECTED)>;
 	};
 
+	can0_rx_pa13: can0_rx_pa13 {
+		pinmux = <MSP_PINMUX(35,CANFD0_CANRX)>;
+		input-enable;
+	};
+
+	can0_tx_pa12: can0_tx_pa12 {
+		pinmux = <MSP_PINMUX(34,CANFD0_CANTX)>;
+	};
+
 };

--- a/mspm0/CMakeLists.txt
+++ b/mspm0/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_HAS_MSPM0SDK)
     source/ti/driverlib/dl_i2c.c
     source/ti/driverlib/dl_adc12.c
     source/ti/driverlib/dl_vref.c
+    source/ti/driverlib/dl_mcan.c
     source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.c
     )
 endif()


### PR DESCRIPTION
Tested with samples/drivers/can/babbling and samples/drivers/can/counter